### PR TITLE
Take care about network delay

### DIFF
--- a/device_tracker.go
+++ b/device_tracker.go
@@ -125,6 +125,7 @@ func (self *DeviceTracker) onDeviceConnect1( bdev BridgeDev ) *Device {
     
     if !self.cf.ready {
         self.pendingDevs = append( self.pendingDevs, bdev )
+        self.cf.delayed = true
         fmt.Printf("Device attached, but ControlFloor not ready.\n  udid=%s\n", udid )
         return nil
     }


### PR DESCRIPTION
added var delayed to the ControlFloor class in order to notify the DeviceTracker when CF is ready.

If the ControlFloor server is a remote server it sometime occur that the connection to the server is established after the DeviceTracker tries to register the devices against CF. 

In this case DeviceTracker stores the devices in pendingDevs and waits for the notifcation of  controlfoor.go but this notification only happens if the server can't be reached at all. 